### PR TITLE
Several Changes

### DIFF
--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -124,7 +124,6 @@ WinExe.prototype._getArgsForPsExec = function () {
  */
 WinExe.prototype._exec = function (callback) {
     var self = this;
-//    var cp = spawn(this.winexe, this._getArgs());
     var cp = spawn(this.winexe, this._getArgs(), {
         cwd: path.join(__dirname, '..')
     });

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -3,6 +3,10 @@
 var getos = require('getos');
 var path = require('path');
 var spawn = require('child_process').spawn;
+var events = require('events');
+var sh = require('shelljs');
+var rl = require('readline');
+var devnull = require('dev-null');
 
 var getUsername = require('./username.js');
 
@@ -18,10 +22,32 @@ function WinExe(options) {
     this.password = options.password;
     this.isWindows = process.platform === 'win32';
     this.options = {};
-    this.winexe = this.isWindows ? path.join(__dirname, '..', 'bin', 'paexec.exe') : 'winexe';
+    if(this.isWindows) {
+        if(sh.which('paexec')) {
+            this.winexe = sh.which('paexec');
+        }
+        else if(sh.which('psexec')) {
+            this.winexe = sh.which('psexec');
+        }
+        else {
+            this.winexe = path.join(__dirname, '..', 'bin', 'paexec.exe');
+        }
+    }
+    else if(sh.which('winexe')){
+        this.winexe = sh.which('winexe');
+    }
 
+    events.EventEmitter.call(this);
     return this;
 }
+
+WinExe.super_ = events.EventEmitter;
+WinExe.prototype = Object.create(events.EventEmitter.prototype, {
+    constructor: {
+        value: WinExe,
+        enumerable: false
+    }
+});
 
 /**
  * Return args for winexe or psexec
@@ -97,26 +123,37 @@ WinExe.prototype._getArgsForPsExec = function () {
  * @private
  */
 WinExe.prototype._exec = function (callback) {
+    var self = this;
+//    var cp = spawn(this.winexe, this._getArgs());
     var cp = spawn(this.winexe, this._getArgs(), {
-        cwd: path.join(__dirname, '..'),
-        stdio: ['ignore', 'pipe', 'pipe']
+        cwd: path.join(__dirname, '..')
     });
+
+
+    var stdoutRL = rl.createInterface({input:cp.stdout, output:devnull()});
+    var stderrRL = rl.createInterface({input:cp.stderr, output:devnull()});
 
     var stdout = '';
 
-    cp.stdout.on('data', function (data) {
+    stdoutRL.on('line', function (data) {
         stdout += data;
+        self.emit('stdout', data);
     });
 
     var stderr = '';
 
-    cp.stderr.on('data', function (data) {
+    stderrRL.on('data', function (data) {
         stderr += data;
+        self.emit('stderr', data);
+    });
+
+    cp.on('error', function(err) {
+        self.emit('error', err);
     });
 
     cp.on('close', function (code) {
         if (code !== 0) {
-            callback(new Error('Exit code: ' + code + '. ' + stderr.trim()));
+            callback(new Error('Exit code: ' + code + '. ' + stderr.trim()), stdout, stderr);
         } else {
             callback(null, stdout, stderr);
         }
@@ -145,7 +182,7 @@ WinExe.prototype.run = function (cmd, options, callback) {
         };
     }
 
-    if (process.platform === 'linux' && process.arch === 'x64') {
+    if (self.winexe === undefined && process.platform === 'linux' && process.arch === 'x64') {
         getos(function (err, os) {
             if (err) {
                 callback(err);

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -26,9 +26,6 @@ function WinExe(options) {
         if(sh.which('paexec')) {
             this.winexe = sh.which('paexec');
         }
-        else if(sh.which('psexec')) {
-            this.winexe = sh.which('psexec');
-        }
         else {
             this.winexe = path.join(__dirname, '..', 'bin', 'paexec.exe');
         }
@@ -110,9 +107,23 @@ WinExe.prototype._getArgsForPsExec = function () {
         args.push('-p', this.password);
     }
 
+    args.push('-h');
     args.push('-accepteula');
 
-    args = args.concat(this.cmd.split(' '));
+    var inQuote = false;
+    var cmd = '';
+    for(var i=0;i<this.cmd.length;i+=1) {
+        if(this.cmd[i] === '"') {
+            inQuote = !inQuote;
+        }
+        else if(this.cmd[i] === ' ') {
+            cmd += (inQuote) ? ' ' : '\u0001';
+        }
+        else {
+            cmd += this.cmd[i];
+        }
+    }
+    args = args.concat(cmd.split('\u0001'));
 
     return args;
 };
@@ -124,8 +135,11 @@ WinExe.prototype._getArgsForPsExec = function () {
  */
 WinExe.prototype._exec = function (callback) {
     var self = this;
+    var stdio = (this.isWindows) ? ['ignore', 'pipe', 'pipe'] : undefined;
+    console.log(this._getArgs());
     var cp = spawn(this.winexe, this._getArgs(), {
-        cwd: path.join(__dirname, '..')
+        cwd: path.join(__dirname, '..'),
+        stdio: stdio
     });
 
 
@@ -135,14 +149,14 @@ WinExe.prototype._exec = function (callback) {
     var stdout = '';
 
     stdoutRL.on('line', function (data) {
-        stdout += data;
+        stdout += data+'\n';
         self.emit('stdout', data);
     });
 
     var stderr = '';
 
-    stderrRL.on('data', function (data) {
-        stderr += data;
+    stderrRL.on('line', function (data) {
+        stderr += data+'\n';
         self.emit('stderr', data);
     });
 

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -21,7 +21,7 @@ function WinExe(options) {
     this.username = getUsername(options.username);
     this.password = options.password;
     this.isWindows = process.platform === 'win32';
-    this.options = {};
+    this.options = options;
     if(this.isWindows) {
         if(sh.which('paexec')) {
             this.winexe = sh.which('paexec');

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -82,7 +82,11 @@ WinExe.prototype._getArgsForWinExe = function () {
         if (this.options.uninstall) {
             args.push('--uninstall');
         }
+        if (this.options.system) {
+            args.push('--system');
+        }
     }
+
 
     args.push('//' + this.host, this.cmd);
 
@@ -107,7 +111,15 @@ WinExe.prototype._getArgsForPsExec = function () {
         args.push('-p', this.password);
     }
 
-    args.push('-h');
+    if (this.options) {
+        if (this.options.system) {
+            args.push('-s');
+        }
+        if (this.options.elevated) {
+            args.push('-h');
+        }
+    }
+
     args.push('-accepteula');
 
     var inQuote = false;
@@ -136,7 +148,6 @@ WinExe.prototype._getArgsForPsExec = function () {
 WinExe.prototype._exec = function (callback) {
     var self = this;
     var stdio = (this.isWindows) ? ['ignore', 'pipe', 'pipe'] : undefined;
-    console.log(this._getArgs());
     var cp = spawn(this.winexe, this._getArgs(), {
         cwd: path.join(__dirname, '..'),
         stdio: stdio

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "homepage": "https://github.com/R-Vision/winexe#readme",
   "dependencies": {
-    "getos": "^2.4.0"
+    "dev-null": "^0.1.1",
+    "getos": "^2.4.0",
+    "shelljs": "^0.5.3"
   }
 }


### PR DESCRIPTION
I've made several changes to your WinExe module and figured I would share them with you to see if you wanted to merge them in. Basically, these are the changes:
- If available, use the version of `winexe` in the systems path
- Make the object an event emitter and emit `stderr` and `stdout` events for each line of child process output
- When using PaExec, don't split on spaces inside quotes
- Added an option to use the elevate bit (only for PaExec)
- Added an option to use the system account
- Make the options hash passed into the constructor an object field (an empty hash was being created in the constructor before)

Feel free to ask me any questions or make any requests in the pull request comments.
