### PR TITLE
terminate winexe child process execution after specified timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ var WinExe = require('winexe');
 var winexe = new WinExe({
     username: 'LOGIN',
     password: 'PASSWORD',
-    host: 'IP-ADDRESS'
+    host: 'IP-ADDRESS',
+    timeout: 60000 // optional timeout in ms, winexe process will be killed with SIGKILL
 });
 
 // Run command on remote host

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -196,8 +196,6 @@ WinExe.prototype._exec = function (callback) {
             callback(null, stdout, stderr);
         }
     });
-
-    return cp;
 };
 
 /**

--- a/lib/winexe.js
+++ b/lib/winexe.js
@@ -159,6 +159,13 @@ WinExe.prototype._exec = function (callback) {
     var stderrRL = rl.createInterface({input: cp.stderr, output: devnull()});
 
     var stdout = '';
+    var watchDog;
+    
+    if (this.options.timeout) {
+        watchDog = setTimeout(function () {
+            process.kill(cp.pid, 'SIGKILL');
+        }, this.options.timeout);
+    }
 
     stdoutRL.on('line', function (data) {
         stdout += data + '\n';
@@ -173,16 +180,24 @@ WinExe.prototype._exec = function (callback) {
     });
 
     cp.on('error', function (err) {
+        if (watchDog) {
+            clearTimeout(watchDog);
+        }
         self.emit('error', err);
     });
 
     cp.on('close', function (code) {
+        if (watchDog) {
+            clearTimeout(watchDog);
+        }
         if (code !== 0) {
             callback(new Error('Exit code: ' + code + '. ' + stderr.trim()), stdout, stderr);
         } else {
             callback(null, stdout, stderr);
         }
     });
+
+    return cp;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winexe",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Wrapper around the winexe and psexec/paexec",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winexe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Wrapper around the winexe and psexec/paexec",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
We stop winexe sub-process with native nodejs process.kill(pid, 'SIGKILL') in 'not so rare' cases when it hangs and never finish its execution.
